### PR TITLE
Migrate Call Sites (GameManager → GameRunState)

### DIFF
--- a/scripts/GameBoard.gd
+++ b/scripts/GameBoard.gd
@@ -239,7 +239,7 @@ func instantiate_tile_visual(tile_type: int, grid_pos: Vector2, scale_factor: fl
 				textures_arr = []
 			if typeof(reveals) != TYPE_DICTIONARY:
 				reveals = {}
-			tile.configure_unmovable_hard(unmovable_meta.get("hits", 1), unmovable_meta.get("type", GameManager.unmovable_type), textures_arr, reveals)
+			tile.configure_unmovable_hard(unmovable_meta.get("hits", 1), unmovable_meta.get("type", GameRunState.unmovable_type), textures_arr, reveals)
 
 	if tile != null:
 		tile.connect("tile_clicked", Callable(self, "_on_tile_clicked"))
@@ -259,7 +259,7 @@ func create_visual_grid():
 
 # Collectible spawning and handling
 func spawn_collectible_visual(x: int, y: int, coll_type: String = "coin"):
-	if x < 0 or x >= GameManager.GRID_WIDTH or y < 0 or y >= GameManager.GRID_HEIGHT:
+	if x < 0 or x >= GameRunState.GRID_WIDTH or y < 0 or y >= GameRunState.GRID_HEIGHT:
 		return
 
 	var existing_tile = tiles[x][y] if x < tiles.size() and y < tiles[x].size() else null
@@ -329,8 +329,8 @@ func _apply_screen_shake(duration: float, intensity: float):
 func _on_game_over():
 	print("[GameBoard] Game Over")
 	# Cleanup or final actions on game over
-	for x in range(GameManager.GRID_WIDTH):
-		for y in range(GameManager.GRID_HEIGHT):
+	for x in range(GameRunState.GRID_WIDTH):
+		for y in range(GameRunState.GRID_HEIGHT):
 			var tile = tiles[x][y]
 			if tile:
 				tile.set_process_input(false)  # Disable input processing for tiles
@@ -379,9 +379,9 @@ func world_to_grid_position(world_pos: Vector2) -> Vector2:
 func update_tile_visual(grid_pos: Vector2, new_type: int):
 	"""Update a tile's visual appearance to match a new type
 	Used for bonus moves conversion"""
-	if grid_pos.x < 0 or grid_pos.x >= GameManager.GRID_WIDTH:
+	if grid_pos.x < 0 or grid_pos.x >= GameRunState.GRID_WIDTH:
 		return
-	if grid_pos.y < 0 or grid_pos.y >= GameManager.GRID_HEIGHT:
+	if grid_pos.y < 0 or grid_pos.y >= GameRunState.GRID_HEIGHT:
 		return
 
 	var tile = tiles[int(grid_pos.x)][int(grid_pos.y)]
@@ -523,7 +523,7 @@ func deferred_gravity_then_refill() -> void:
 
 func _task_deferred_gravity_then_refill() -> void:
 	print("[GameBoard] deferred_gravity_then_refill started")
-	if GameManager.pending_level_complete or GameManager.level_transitioning:
+	if GameRunState.pending_level_complete or GameRunState.level_transitioning:
 		print("[GameBoard] deferred_gravity_then_refill aborted: level transition pending")
 		return
 
@@ -622,7 +622,7 @@ func draw_board_borders():
 	# A3: Delegated to BorderRenderer
 	if typeof(GameManager) == TYPE_NIL:
 		return
-	if not GameManager.initialized or GameManager.grid == null or GameManager.grid.size() == 0:
+	if not GameRunState.initialized or GameRunState.grid == null or GameRunState.grid.size() == 0:
 		return
 	if border_container == null:
 		border_container = Node2D.new()

--- a/scripts/game/BoardActionExecutor.gd
+++ b/scripts/game/BoardActionExecutor.gd
@@ -19,7 +19,7 @@ static func execute_board_action(board: Node, positions: Array, effect_fn: Calla
 	await board.animate_destroy_tiles(positions)
 	var pts = GameManager.calculate_points(positions.size())
 	for pos in positions:
-		GameManager.grid[int(pos.x)][int(pos.y)] = 0
+		GameRunState.grid[int(pos.x)][int(pos.y)] = 0
 	if pts > 0:
 		GameManager.add_score(pts)
 	await board.animate_gravity()
@@ -42,13 +42,13 @@ static func execute_line_clear(board: Node, positions: Array, tiles_ref: Array) 
 		if tile_instance and tile_instance.is_unmovable_hard:
 			var destroyed = tile_instance.take_hit(1)
 			if destroyed:
-				GameManager.grid[gx][gy] = 0
+				GameRunState.grid[gx][gy] = 0
 				if not tile_instance.is_queued_for_deletion():
 					tile_instance.queue_free()
 				tiles_ref[gx][gy] = null
 				scoring_count += 1
 		else:
-			GameManager.grid[gx][gy] = 0
+			GameRunState.grid[gx][gy] = 0
 			scoring_count += 1
 	var pts = GameManager.calculate_points(scoring_count)
 	if pts > 0:
@@ -64,28 +64,28 @@ static func execute_line_clear(board: Node, positions: Array, tiles_ref: Array) 
 static func activate_shuffle_booster(board: Node) -> void:
 	if not RewardManager.use_booster("shuffle"):
 		return
-	GameManager.processing_moves = true
+	GameRunState.processing_moves = true
 	AudioManager.play_sfx("booster_shuffle")
 	if GameManager.shuffle_until_moves_available():
 		await board.animate_shuffle()
-	GameManager.processing_moves = false
+	GameRunState.processing_moves = false
 
 static func activate_swap_booster(board: Node, tiles_ref: Array, x1: int, y1: int, x2: int, y2: int) -> void:
 	if not RewardManager.use_booster("swap"):
 		return
-	GameManager.processing_moves = true
+	GameRunState.processing_moves = true
 	AudioManager.play_sfx("booster_swap")
 	if GameManager.is_cell_blocked(x1, y1) or GameManager.is_cell_blocked(x2, y2):
-		GameManager.processing_moves = false
+		GameRunState.processing_moves = false
 		return
 	var tile1 = tiles_ref[x1][y1]
 	var tile2 = tiles_ref[x2][y2]
 	if not tile1 or not tile2:
-		GameManager.processing_moves = false
+		GameRunState.processing_moves = false
 		return
-	var temp = GameManager.grid[x1][y1]
-	GameManager.grid[x1][y1] = GameManager.grid[x2][y2]
-	GameManager.grid[x2][y2] = temp
+	var temp = GameRunState.grid[x1][y1]
+	GameRunState.grid[x1][y1] = GameRunState.grid[x2][y2]
+	GameRunState.grid[x2][y2] = temp
 	var t1 = tile1.animate_swap_to(board.grid_to_world_position(Vector2(x2, y2)))
 	var t2 = tile2.animate_swap_to(board.grid_to_world_position(Vector2(x1, y1)))
 	tiles_ref[x1][y1] = tile2
@@ -97,15 +97,15 @@ static func activate_swap_booster(board: Node, tiles_ref: Array, x1: int, y1: in
 	board._check_collectibles_at_bottom()
 	if GameManager.find_matches().size() > 0:
 		await board.process_cascade()
-	GameManager.processing_moves = false
+	GameRunState.processing_moves = false
 
 static func activate_chain_reaction_booster(board: Node, BS, x: int, y: int) -> void:
 	if not RewardManager.use_booster("chain_reaction"):
 		return
-	GameManager.processing_moves = true
+	GameRunState.processing_moves = true
 	AudioManager.play_sfx("booster_chain")
-	if GameManager.is_cell_blocked(x, y) or GameManager.get_tile_at(Vector2(x, y)) == GameManager.COLLECTIBLE:
-		GameManager.processing_moves = false
+	if GameManager.is_cell_blocked(x, y) or GameManager.get_tile_at(Vector2(x, y)) == GameRunState.COLLECTIBLE:
+		GameRunState.processing_moves = false
 		return
 	# Compute 3-wave expanding ring inline
 	var waves: Array = [[], [], []]
@@ -115,7 +115,7 @@ static func activate_chain_reaction_booster(board: Node, BS, x: int, y: int) -> 
 	for d in dirs:
 		var nx = x + int(d.x)
 		var ny = y + int(d.y)
-		if nx >= 0 and nx < GameManager.GRID_WIDTH and ny >= 0 and ny < GameManager.GRID_HEIGHT:
+		if nx >= 0 and nx < GameRunState.GRID_WIDTH and ny >= 0 and ny < GameRunState.GRID_HEIGHT:
 			ring2.append(Vector2(nx, ny))
 	waves[1] = ring2
 	var ring3 = []
@@ -124,7 +124,7 @@ static func activate_chain_reaction_booster(board: Node, BS, x: int, y: int) -> 
 			if abs(dx) + abs(dy) == 2:
 				var nx2 = x + dx
 				var ny2 = y + dy
-				if nx2 >= 0 and nx2 < GameManager.GRID_WIDTH and ny2 >= 0 and ny2 < GameManager.GRID_HEIGHT:
+				if nx2 >= 0 and nx2 < GameRunState.GRID_WIDTH and ny2 >= 0 and ny2 < GameRunState.GRID_HEIGHT:
 					ring3.append(Vector2(nx2, ny2))
 	waves[2] = ring3
 
@@ -132,13 +132,13 @@ static func activate_chain_reaction_booster(board: Node, BS, x: int, y: int) -> 
 	for wave in waves:
 		if wave.size() == 0:
 			continue
-		var valid = wave.filter(func(p): return not GameManager.is_cell_blocked(int(p.x), int(p.y)) and GameManager.get_tile_at(p) > 0 and GameManager.get_tile_at(p) != GameManager.COLLECTIBLE)
+		var valid = wave.filter(func(p): return not GameManager.is_cell_blocked(int(p.x), int(p.y)) and GameManager.get_tile_at(p) > 0 and GameManager.get_tile_at(p) != GameRunState.COLLECTIBLE)
 		if valid.size() == 0:
 			continue
 		await board.highlight_special_activation(valid)
 		await board.animate_destroy_tiles(valid)
 		for pos in valid:
-			GameManager.grid[int(pos.x)][int(pos.y)] = 0
+			GameRunState.grid[int(pos.x)][int(pos.y)] = 0
 			total_scoring += 1
 		await board.get_tree().create_timer(0.3).timeout
 	var pts = GameManager.calculate_points(total_scoring)
@@ -148,152 +148,152 @@ static func activate_chain_reaction_booster(board: Node, BS, x: int, y: int) -> 
 	if board.has_method("_check_collectibles_at_bottom"):
 		await board._check_collectibles_at_bottom()
 	await board.process_cascade()
-	GameManager.processing_moves = false
+	GameRunState.processing_moves = false
 
 static func activate_bomb_3x3_booster(board: Node, BS, x: int, y: int) -> void:
 	if not RewardManager.use_booster("bomb_3x3"):
 		return
-	GameManager.processing_moves = true
+	GameRunState.processing_moves = true
 	AudioManager.play_sfx("booster_bomb_3x3")
 	if GameManager.is_cell_blocked(x, y):
-		GameManager.processing_moves = false
+		GameRunState.processing_moves = false
 		return
 	var positions = []
 	for dx in range(-1, 2):
 		for dy in range(-1, 2):
 			var nx = x + dx
 			var ny = y + dy
-			if nx >= 0 and nx < GameManager.GRID_WIDTH and ny >= 0 and ny < GameManager.GRID_HEIGHT:
-				if not GameManager.is_cell_blocked(nx, ny) and GameManager.get_tile_at(Vector2(nx, ny)) != GameManager.COLLECTIBLE:
+			if nx >= 0 and nx < GameRunState.GRID_WIDTH and ny >= 0 and ny < GameRunState.GRID_HEIGHT:
+				if not GameManager.is_cell_blocked(nx, ny) and GameManager.get_tile_at(Vector2(nx, ny)) != GameRunState.COLLECTIBLE:
 					positions.append(Vector2(nx, ny))
 	if positions.size() > 0:
 		await execute_board_action(board, positions)
-	GameManager.processing_moves = false
+	GameRunState.processing_moves = false
 
 static func activate_line_blast_booster(board: Node, BS, direction: String, center_x: int, center_y: int) -> void:
 	if not RewardManager.use_booster("line_blast"):
 		return
-	GameManager.processing_moves = true
+	GameRunState.processing_moves = true
 	AudioManager.play_sfx("booster_line")
 	var positions = []
 	for offset in range(-1, 2):
 		if direction == "horizontal":
 			var ty = center_y + offset
-			if ty >= 0 and ty < GameManager.GRID_HEIGHT:
-				for cx in range(GameManager.GRID_WIDTH):
-					if not GameManager.is_cell_blocked(cx, ty) and GameManager.get_tile_at(Vector2(cx, ty)) != GameManager.COLLECTIBLE:
+			if ty >= 0 and ty < GameRunState.GRID_HEIGHT:
+				for cx in range(GameRunState.GRID_WIDTH):
+					if not GameManager.is_cell_blocked(cx, ty) and GameManager.get_tile_at(Vector2(cx, ty)) != GameRunState.COLLECTIBLE:
 						positions.append(Vector2(cx, ty))
 				board._create_lightning_beam_horizontal(ty, Color(1.0, 0.9, 0.2))
 				await board.get_tree().create_timer(0.05).timeout
 		else:
 			var tx = center_x + offset
-			if tx >= 0 and tx < GameManager.GRID_WIDTH:
-				for cy in range(GameManager.GRID_HEIGHT):
-					if not GameManager.is_cell_blocked(tx, cy) and GameManager.get_tile_at(Vector2(tx, cy)) != GameManager.COLLECTIBLE:
+			if tx >= 0 and tx < GameRunState.GRID_WIDTH:
+				for cy in range(GameRunState.GRID_HEIGHT):
+					if not GameManager.is_cell_blocked(tx, cy) and GameManager.get_tile_at(Vector2(tx, cy)) != GameRunState.COLLECTIBLE:
 						positions.append(Vector2(tx, cy))
 				board._create_lightning_beam_vertical(tx, Color(0.4, 0.9, 1.0))
 				await board.get_tree().create_timer(0.05).timeout
 	if positions.size() > 0:
 		await execute_board_action(board, positions)
-	GameManager.processing_moves = false
+	GameRunState.processing_moves = false
 
 static func activate_hammer_booster(board: Node, x: int, y: int) -> void:
 	if not RewardManager.use_booster("hammer"):
 		return
-	GameManager.processing_moves = true
+	GameRunState.processing_moves = true
 	AudioManager.play_sfx("booster_hammer")
-	if GameManager.is_cell_blocked(x, y) or GameManager.get_tile_at(Vector2(x, y)) == GameManager.COLLECTIBLE:
-		GameManager.processing_moves = false
+	if GameManager.is_cell_blocked(x, y) or GameManager.get_tile_at(Vector2(x, y)) == GameRunState.COLLECTIBLE:
+		GameRunState.processing_moves = false
 		return
 	await execute_board_action(board, [Vector2(x, y)])
-	GameManager.processing_moves = false
+	GameRunState.processing_moves = false
 
 static func activate_tile_squasher_booster(board: Node, BS, x: int, y: int) -> void:
 	if not RewardManager.use_booster("tile_squasher"):
 		return
-	GameManager.processing_moves = true
+	GameRunState.processing_moves = true
 	AudioManager.play_sfx("booster_tile_squasher")
 	var target_type = GameManager.get_tile_at(Vector2(x, y))
-	if GameManager.is_cell_blocked(x, y) or target_type == GameManager.COLLECTIBLE or target_type >= 7:
-		GameManager.processing_moves = false
+	if GameManager.is_cell_blocked(x, y) or target_type == GameRunState.COLLECTIBLE or target_type >= 7:
+		GameRunState.processing_moves = false
 		return
 	var positions = []
-	for gx in range(GameManager.GRID_WIDTH):
-		for gy in range(GameManager.GRID_HEIGHT):
+	for gx in range(GameRunState.GRID_WIDTH):
+		for gy in range(GameRunState.GRID_HEIGHT):
 			if GameManager.get_tile_at(Vector2(gx, gy)) == target_type and not GameManager.is_cell_blocked(gx, gy):
 				positions.append(Vector2(gx, gy))
 	if positions.size() > 0:
 		await execute_board_action(board, positions)
-	GameManager.processing_moves = false
+	GameRunState.processing_moves = false
 
 static func activate_row_clear_booster(board: Node, BS, tiles_ref: Array, row: int) -> void:
 	if not RewardManager.use_booster("row_clear"):
 		return
-	GameManager.processing_moves = true
+	GameRunState.processing_moves = true
 	AudioManager.play_sfx("booster_row_clear")
 	var positions = []
-	for cx in range(GameManager.GRID_WIDTH):
-		if not GameManager.is_cell_blocked(cx, row) and GameManager.get_tile_at(Vector2(cx, row)) != GameManager.COLLECTIBLE:
+	for cx in range(GameRunState.GRID_WIDTH):
+		if not GameManager.is_cell_blocked(cx, row) and GameManager.get_tile_at(Vector2(cx, row)) != GameRunState.COLLECTIBLE:
 			positions.append(Vector2(cx, row))
 	if positions.size() > 0:
 		board._create_lightning_beam_horizontal(row, Color(1.0, 1.0, 0.3))
 		await board.get_tree().create_timer(0.02).timeout
 		board._create_lightning_beam_horizontal(row, Color(1.0, 0.8, 0.0))
-		for cx in range(GameManager.GRID_WIDTH):
+		for cx in range(GameRunState.GRID_WIDTH):
 			if not GameManager.is_cell_blocked(cx, row):
 				board._create_impact_particles(board.grid_to_world_position(Vector2(cx, row)), Color.YELLOW)
 		await execute_line_clear(board, positions, tiles_ref)
-	GameManager.processing_moves = false
+	GameRunState.processing_moves = false
 
 static func activate_column_clear_booster(board: Node, BS, tiles_ref: Array, column: int) -> void:
 	if not RewardManager.use_booster("column_clear"):
 		return
-	GameManager.processing_moves = true
+	GameRunState.processing_moves = true
 	AudioManager.play_sfx("booster_column_clear")
 	var positions = []
-	for cy in range(GameManager.GRID_HEIGHT):
-		if not GameManager.is_cell_blocked(column, cy) and GameManager.get_tile_at(Vector2(column, cy)) != GameManager.COLLECTIBLE:
+	for cy in range(GameRunState.GRID_HEIGHT):
+		if not GameManager.is_cell_blocked(column, cy) and GameManager.get_tile_at(Vector2(column, cy)) != GameRunState.COLLECTIBLE:
 			positions.append(Vector2(column, cy))
 	if positions.size() > 0:
 		board._create_lightning_beam_vertical(column, Color(0.3, 0.8, 1.0))
 		await board.get_tree().create_timer(0.02).timeout
 		board._create_lightning_beam_vertical(column, Color(0.5, 1.0, 1.0))
-		for cy in range(GameManager.GRID_HEIGHT):
+		for cy in range(GameRunState.GRID_HEIGHT):
 			if not GameManager.is_cell_blocked(column, cy):
 				board._create_impact_particles(board.grid_to_world_position(Vector2(column, cy)), Color.CYAN)
 		await execute_line_clear(board, positions, tiles_ref)
-	GameManager.processing_moves = false
+	GameRunState.processing_moves = false
 
 # ── Special tile activation ───────────────────────────────────────────────────
 
 static func activate_special_tile(board: Node, pos: Vector2) -> void:
 	print("[BoardActionExecutor] activate_special_tile at ", pos)
 	var tile_type = GameManager.get_tile_at(pos)
-	GameManager.processing_moves = true
+	GameRunState.processing_moves = true
 	AudioManager.play_sfx("special_activate")
 
 	EventBus.emit_special_tile_activated("tile_%d_%d" % [int(pos.x), int(pos.y)], {
-		"position": pos, "tile_type": tile_type, "level": GameManager.level
+		"position": pos, "tile_type": tile_type, "level": GameRunState.level
 	})
 
 	var sas = load("res://scripts/game/SpecialActivationService.gd")
 	var activation_result = {}
 	if sas != null:
-		activation_result = sas.call("compute_activation", pos, tile_type, GameManager.grid,
-			GameManager.GRID_WIDTH, GameManager.GRID_HEIGHT, GameManager.COLLECTIBLE)
+		activation_result = sas.call("compute_activation", pos, tile_type, GameRunState.grid,
+			GameRunState.GRID_WIDTH, GameRunState.GRID_HEIGHT, GameRunState.COLLECTIBLE)
 
 	var positions_to_clear: Array = activation_result.get("positions", [])
 	var special_tiles_to_activate: Array = activation_result.get("specials", [])
 
-	if tile_type == GameManager.HORIZTONAL_ARROW:
+	if tile_type == GameRunState.HORIZTONAL_ARROW:
 		AudioManager.play_sfx("special_horiz")
 		board._create_lightning_beam_horizontal(int(pos.y), Color(1.0, 0.9, 0.3))
 		await destroy_tiles_immediately(board, positions_to_clear)
-	elif tile_type == GameManager.VERTICAL_ARROW:
+	elif tile_type == GameRunState.VERTICAL_ARROW:
 		AudioManager.play_sfx("special_vert")
 		board._create_lightning_beam_vertical(int(pos.x), Color(0.4, 0.9, 1.0))
 		await destroy_tiles_immediately(board, positions_to_clear)
-	elif tile_type == GameManager.FOUR_WAY_ARROW:
+	elif tile_type == GameRunState.FOUR_WAY_ARROW:
 		AudioManager.play_sfx("special_fourway")
 		var horiz = positions_to_clear.filter(func(p): return p.y == pos.y)
 		var vert  = positions_to_clear.filter(func(p): return p.x == pos.x and p.y != pos.y)
@@ -303,7 +303,7 @@ static func activate_special_tile(board: Node, pos: Vector2) -> void:
 		board._create_lightning_beam_vertical(int(pos.x), Color(1.0, 0.5, 1.0))
 		await destroy_tiles_immediately(board, vert)
 
-	if not GameManager.in_bonus_conversion:
+	if not GameRunState.in_bonus_conversion:
 		GameManager.use_move()
 
 	for st in special_tiles_to_activate:
@@ -315,6 +315,7 @@ static func activate_special_tile(board: Node, pos: Vector2) -> void:
 	if board.has_method("_check_collectibles_at_bottom"):
 		await board._check_collectibles_at_bottom()
 	await board.process_cascade()
+	GameRunState.processing_moves = false
 	print("[BoardActionExecutor] activate_special_tile: complete")
 
 static func activate_special_tile_chain(board: Node, pos: Vector2, tile_type: int) -> void:
@@ -322,21 +323,21 @@ static func activate_special_tile_chain(board: Node, pos: Vector2, tile_type: in
 	var sas = load("res://scripts/game/SpecialActivationService.gd")
 	var chain_result = {}
 	if sas != null:
-		chain_result = sas.call("compute_chain_activation", pos, tile_type, GameManager.grid,
-			GameManager.GRID_WIDTH, GameManager.GRID_HEIGHT, GameManager.COLLECTIBLE)
+		chain_result = sas.call("compute_chain_activation", pos, tile_type, GameRunState.grid,
+			GameRunState.GRID_WIDTH, GameRunState.GRID_HEIGHT, GameRunState.COLLECTIBLE)
 
 	var positions_to_clear: Array = chain_result.get("positions", [])
 	var chained_specials: Array   = chain_result.get("specials", [])
 
-	if tile_type == GameManager.HORIZTONAL_ARROW:
+	if tile_type == GameRunState.HORIZTONAL_ARROW:
 		AudioManager.play_sfx("special_horiz")
 		board._create_lightning_beam_horizontal(int(pos.y), Color(1.0, 0.9, 0.3))
 		await board.get_tree().create_timer(0.1).timeout
-	elif tile_type == GameManager.VERTICAL_ARROW:
+	elif tile_type == GameRunState.VERTICAL_ARROW:
 		AudioManager.play_sfx("special_vert")
 		board._create_lightning_beam_vertical(int(pos.x), Color(0.4, 0.9, 1.0))
 		await board.get_tree().create_timer(0.1).timeout
-	elif tile_type == GameManager.FOUR_WAY_ARROW:
+	elif tile_type == GameRunState.FOUR_WAY_ARROW:
 		AudioManager.play_sfx("special_fourway")
 		board._create_lightning_beam_horizontal(int(pos.y), Color(1.0, 0.5, 1.0))
 		await board.get_tree().create_timer(0.05).timeout
@@ -363,19 +364,19 @@ static func activate_special_tile_chain(board: Node, pos: Vector2, tile_type: in
 				var is_coll       = tile_instance.is_collectible if "is_collectible" in tile_instance else false
 				var tile_type_chk = tile_instance.tile_type if "tile_type" in tile_instance else 0
 				if is_coll:
-					GameManager.grid[gx][gy] = GameManager.COLLECTIBLE
+					GameRunState.grid[gx][gy] = GameRunState.COLLECTIBLE
 				elif tile_type_chk > 0:
-					GameManager.grid[gx][gy] = tile_type_chk
+					GameRunState.grid[gx][gy] = tile_type_chk
 				else:
-					GameManager.grid[gx][gy] = 0
+					GameRunState.grid[gx][gy] = 0
 					if not tile_instance.is_queued_for_deletion(): tile_instance.queue_free()
 					tiles_ref[gx][gy] = null
 					scoring_count += 1
 		else:
-			if t == GameManager.SPREADER:
-				GameManager.spreader_count -= 1
-				GameManager.spreader_positions.erase(clear_pos)
-			GameManager.grid[gx][gy] = 0
+			if t == GameRunState.SPREADER:
+				GameRunState.spreader_count -= 1
+				GameRunState.spreader_positions.erase(clear_pos)
+			GameRunState.grid[gx][gy] = 0
 			scoring_count += 1
 
 	if scoring_count > 0:
@@ -394,7 +395,7 @@ static func destroy_tiles_immediately(board: Node, positions: Array) -> void:
 	var scoring_count = 0
 	for clear_pos in positions:
 		var t = GameManager.get_tile_at(clear_pos)
-		if t > 0 and t != GameManager.COLLECTIBLE:
+		if t > 0 and t != GameRunState.COLLECTIBLE:
 			scoring_count += 1
 
 	await board.animate_destroy_tiles(positions)
@@ -410,13 +411,13 @@ static func destroy_tiles_immediately(board: Node, positions: Array) -> void:
 			tile_instance = tiles_ref[gx][gy]
 
 		if not tile_instance or not is_instance_valid(tile_instance):
-			if t == GameManager.SPREADER:
+			if t == GameRunState.SPREADER:
 				if GameManager.has_method("report_spreader_destroyed"):
 					GameManager.report_spreader_destroyed(clear_pos)
 				else:
-					GameManager.spreader_count -= 1
-					GameManager.spreader_positions.erase(clear_pos)
-			GameManager.grid[gx][gy] = 0
+					GameRunState.spreader_count -= 1
+					GameRunState.spreader_positions.erase(clear_pos)
+			GameRunState.grid[gx][gy] = 0
 			continue
 
 		if "is_unmovable_hard" in tile_instance and tile_instance.is_unmovable_hard:
@@ -427,29 +428,29 @@ static func destroy_tiles_immediately(board: Node, positions: Array) -> void:
 				var is_coll       = tile_instance.is_collectible if "is_collectible" in tile_instance else false
 				var tile_type_chk = tile_instance.tile_type if "tile_type" in tile_instance else 0
 				if is_coll:
-					GameManager.grid[gx][gy] = GameManager.COLLECTIBLE
+					GameRunState.grid[gx][gy] = GameRunState.COLLECTIBLE
 				elif tile_type_chk > 0:
-					GameManager.grid[gx][gy] = tile_type_chk
+					GameRunState.grid[gx][gy] = tile_type_chk
 				else:
-					GameManager.grid[gx][gy] = 0
+					GameRunState.grid[gx][gy] = 0
 					if not tile_instance.is_queued_for_deletion(): tile_instance.queue_free()
 					tiles_ref[gx][gy] = null
 		else:
-			if t == GameManager.SPREADER:
+			if t == GameRunState.SPREADER:
 				if GameManager.has_method("report_spreader_destroyed"):
 					GameManager.report_spreader_destroyed(clear_pos)
 				else:
-					GameManager.spreader_count -= 1
-					GameManager.spreader_positions.erase(clear_pos)
-			GameManager.grid[gx][gy] = 0
+					GameRunState.spreader_count -= 1
+					GameRunState.spreader_positions.erase(clear_pos)
+			GameRunState.grid[gx][gy] = 0
 			if tile_instance and not tile_instance.is_queued_for_deletion():
 				tile_instance.queue_free()
 			tiles_ref[gx][gy] = null
 
-	if GameManager.use_spreader_objective:
-		GameManager.emit_signal("spreaders_changed", GameManager.spreader_count)
-		if GameManager.spreader_count == 0:
-			if not GameManager.pending_level_complete and not GameManager.level_transitioning:
+	if GameRunState.use_spreader_objective:
+		GameManager.emit_signal("spreaders_changed", GameRunState.spreader_count)
+		if GameRunState.spreader_count == 0:
+			if not GameRunState.pending_level_complete and not GameRunState.level_transitioning:
 				GameManager._attempt_level_complete()
 
 	if scoring_count > 0:

--- a/scripts/game/BoardAnimator.gd
+++ b/scripts/game/BoardAnimator.gd
@@ -18,7 +18,7 @@ static func animate_destroy_tiles(board: Node, tiles_ref: Array, positions: Arra
 	for pos in positions:
 		if pos.x < 0 or pos.y < 0:
 			continue
-		if pos.x >= GameManager.GRID_WIDTH or pos.y >= GameManager.GRID_HEIGHT:
+		if pos.x >= GameRunState.GRID_WIDTH or pos.y >= GameRunState.GRID_HEIGHT:
 			continue
 
 		var gx = int(pos.x)
@@ -125,8 +125,8 @@ static func animate_destroy_matches_except(board: Node, tiles_ref: Array, matche
 
 static func animate_shuffle(board: Node, tiles_ref: Array) -> void:
 	var shuffle_tweens = []
-	for x in range(GameManager.GRID_WIDTH):
-		for y in range(GameManager.GRID_HEIGHT):
+	for x in range(GameRunState.GRID_WIDTH):
+		for y in range(GameRunState.GRID_HEIGHT):
 			var tile = tiles_ref[x][y] if x < tiles_ref.size() and y < tiles_ref[x].size() else null
 			if tile and not GameManager.is_cell_blocked(x, y):
 				var new_type = GameManager.get_tile_at(Vector2(x, y))
@@ -171,7 +171,7 @@ static func highlight_special_activation(board: Node, tiles_ref: Array, position
 	for pos in positions:
 		if pos.x < 0 or pos.y < 0:
 			continue
-		if pos.x >= GameManager.GRID_WIDTH or pos.y >= GameManager.GRID_HEIGHT:
+		if pos.x >= GameRunState.GRID_WIDTH or pos.y >= GameRunState.GRID_HEIGHT:
 			continue
 		var tile = tiles_ref[int(pos.x)][int(pos.y)] if int(pos.x) < tiles_ref.size() else null
 		if tile:

--- a/scripts/game/BoardInputHandler.gd
+++ b/scripts/game/BoardInputHandler.gd
@@ -23,11 +23,11 @@ func handle_tile_clicked(tile) -> void:
 		print("[BoardInputHandler] Clicked tile is unmovable, ignoring")
 		return
 
-	if GameManager.processing_moves:
+	if GameRunState.processing_moves:
 		print("[BoardInputHandler] Move processing blocked")
 		return
 
-	if GameManager.level_transitioning:
+	if GameRunState.level_transitioning:
 		print("[BoardInputHandler] Level transitioning, clicks blocked")
 		return
 
@@ -115,9 +115,9 @@ func handle_tile_swiped(tile, direction: Vector2) -> void:
 
 	if tile.is_unmovable:
 		return
-	if GameManager.processing_moves:
+	if GameRunState.processing_moves:
 		return
-	if GameManager.level_transitioning:
+	if GameRunState.level_transitioning:
 		return
 
 	if board.selected_tile:
@@ -139,7 +139,7 @@ func handle_tile_swiped(tile, direction: Vector2) -> void:
 # ── Swap execution ────────────────────────────────────────────────────────────
 
 func perform_swap(tile1, tile2) -> void:
-	GameManager.processing_moves = true
+	GameRunState.processing_moves = true
 	print("[BoardInputHandler] perform_swap: start")
 
 	tile1.set_selected(false)
@@ -159,7 +159,7 @@ func perform_swap(tile1, tile2) -> void:
 		tw.tween_property(tile2, "position", tile2.position, 0.08)
 		if tw:
 			await tw.finished
-		GameManager.processing_moves = false
+		GameRunState.processing_moves = false
 		print("[BoardInputHandler] perform_swap: denied")
 		return
 
@@ -194,7 +194,7 @@ func perform_swap(tile1, tile2) -> void:
 				swap_pos_in_match = fallback
 
 		await board.process_cascade(swap_pos_in_match)
-		GameManager.processing_moves = false
+		GameRunState.processing_moves = false
 		print("[BoardInputHandler] perform_swap: matched, cascade done")
 	else:
 		# Revert
@@ -211,5 +211,5 @@ func perform_swap(tile1, tile2) -> void:
 		if rt1: await rt1.finished
 		if rt2: await rt2.finished
 
-		GameManager.processing_moves = false
+		GameRunState.processing_moves = false
 		print("[BoardInputHandler] perform_swap: no match, reverted")

--- a/scripts/game/BoardLayout.gd
+++ b/scripts/game/BoardLayout.gd
@@ -18,8 +18,8 @@ static func calculate_responsive_layout(gameboard: Node) -> void:
     var available_width = screen_size.x - (board_margin * 2)
     var available_height = screen_size.y - ui_top_space - ui_bottom_space - (board_margin * 2)
 
-    var grid_w = GameManager.GRID_WIDTH
-    var grid_h = GameManager.GRID_HEIGHT
+    var grid_w = GameRunState.GRID_WIDTH
+    var grid_h = GameRunState.GRID_HEIGHT
     var max_tile_size_width = available_width / max(1, grid_w)
     var max_tile_size_height = available_height / max(1, grid_h)
     var tile_size = min(max_tile_size_width, max_tile_size_height)
@@ -48,8 +48,8 @@ static func setup_background(gameboard: Node) -> void:
         return
 
     var board_size = Vector2(
-        GameManager.GRID_WIDTH * gameboard.tile_size + 20,
-        GameManager.GRID_HEIGHT * gameboard.tile_size + 20
+        GameRunState.GRID_WIDTH * gameboard.tile_size + 20,
+        GameRunState.GRID_HEIGHT * gameboard.tile_size + 20
     )
 
     if gameboard.has_node("Background"):
@@ -100,8 +100,8 @@ static func setup_tile_area_overlay(gameboard: Node) -> void:
         gameboard.tile_area_overlay = overlay
         return
 
-    for x in range(GameManager.GRID_WIDTH):
-        for y in range(GameManager.GRID_HEIGHT):
+    for x in range(GameRunState.GRID_WIDTH):
+        for y in range(GameRunState.GRID_HEIGHT):
             if not GameManager.is_cell_blocked(x, y):
                 var tile_overlay = ColorRect.new()
                 tile_overlay.color = Color(0.1, 0.15, 0.25, 0.5)

--- a/scripts/game/BoardSetup.gd
+++ b/scripts/game/BoardSetup.gd
@@ -17,13 +17,13 @@ static func calculate_responsive_layout(board: Node) -> void:
 	var available_width = screen_size.x - (board.board_margin * 2)
 	var available_height = screen_size.y - ui_top_space - ui_bottom_space - (board.board_margin * 2)
 
-	var max_tile_size_width  = available_width  / GameManager.GRID_WIDTH
-	var max_tile_size_height = available_height / GameManager.GRID_HEIGHT
+	var max_tile_size_width  = available_width  / GameRunState.GRID_WIDTH
+	var max_tile_size_height = available_height / GameRunState.GRID_HEIGHT
 	board.tile_size = min(max_tile_size_width, max_tile_size_height)
 	board.tile_size = max(board.tile_size, 50.0)
 
-	var total_grid_width  = GameManager.GRID_WIDTH  * board.tile_size
-	var total_grid_height = GameManager.GRID_HEIGHT * board.tile_size
+	var total_grid_width  = GameRunState.GRID_WIDTH  * board.tile_size
+	var total_grid_height = GameRunState.GRID_HEIGHT * board.tile_size
 
 	board.grid_offset = Vector2(
 		(screen_size.x - total_grid_width) / 2,
@@ -41,8 +41,8 @@ static func setup_background(board: Node) -> void:
 	if background:
 		background.visible = false
 		var board_size = Vector2(
-			GameManager.GRID_WIDTH  * board.tile_size + 20,
-			GameManager.GRID_HEIGHT * board.tile_size + 20
+			GameRunState.GRID_WIDTH  * board.tile_size + 20,
+			GameRunState.GRID_HEIGHT * board.tile_size + 20
 		)
 		background.color    = board.BOARD_BACKGROUND_COLOR
 		background.size     = board_size
@@ -78,8 +78,8 @@ static func setup_tile_area_overlay(board: Node) -> void:
 	overlay.z_index      = -50
 	overlay.mouse_filter = Control.MOUSE_FILTER_IGNORE
 
-	for x in range(GameManager.GRID_WIDTH):
-		for y in range(GameManager.GRID_HEIGHT):
+	for x in range(GameRunState.GRID_WIDTH):
+		for y in range(GameRunState.GRID_HEIGHT):
 			if not GameManager.is_cell_blocked(x, y):
 				var rect = ColorRect.new()
 				rect.color        = Color(0.1, 0.15, 0.25, 0.5)
@@ -194,7 +194,7 @@ static func show_skip_bonus_hint(board: Node) -> void:
 	lbl.add_theme_color_override("font_color", Color(1.0, 1.0, 0.3, 1.0))
 
 	var viewport_size = board.get_viewport().get_visible_rect().size
-	var board_bottom  = board.grid_offset.y + (board.tile_size * GameManager.GRID_HEIGHT)
+	var board_bottom  = board.grid_offset.y + (board.tile_size * GameRunState.GRID_HEIGHT)
 	lbl.position              = Vector2(viewport_size.x / 2 - 150, board_bottom + 20)
 	lbl.custom_minimum_size   = Vector2(300, 60)
 
@@ -225,11 +225,11 @@ static func on_level_loaded_setup(board: Node) -> void:
 
 	# Reset game-state flags
 	if typeof(GameManager) != TYPE_NIL:
-		GameManager.processing_moves       = false
-		GameManager.level_transitioning    = false
-		GameManager.pending_level_complete = false
-		GameManager.pending_level_failed   = false
-		GameManager.in_bonus_conversion    = false
+		GameRunState.processing_moves       = false
+		GameRunState.level_transitioning    = false
+		GameRunState.pending_level_complete = false
+		GameRunState.pending_level_failed   = false
+		GameRunState.in_bonus_conversion    = false
 		GameManager.reset_combo()
 		print("[BoardSetup] Safety flags cleared")
 

--- a/scripts/game/BoardVisuals.gd
+++ b/scripts/game/BoardVisuals.gd
@@ -34,7 +34,7 @@ static func clear_tiles(gameboard: Node, tiles_ref: Array) -> void:
 	for i in range(tiles_ref.size()):
 		tiles_ref[i] = []
 	# ensure length
-	while tiles_ref.size() < GameManager.GRID_WIDTH:
+	while tiles_ref.size() < GameRunState.GRID_WIDTH:
 		tiles_ref.append([])
 
 static func instantiate_tile_visual(gameboard: Node, tile_scene: PackedScene, tile_type: int, grid_pos: Vector2, scale_factor: float, unmovable_meta = null) -> Node:
@@ -63,7 +63,7 @@ static func instantiate_tile_visual(gameboard: Node, tile_scene: PackedScene, ti
 				textures_arr = []
 			if typeof(reveals) != TYPE_DICTIONARY:
 				reveals = {}
-			tile.configure_unmovable_hard(unmovable_meta.get("hits",1), unmovable_meta.get("type", GameManager.unmovable_type), textures_arr, reveals)
+			tile.configure_unmovable_hard(unmovable_meta.get("hits",1), unmovable_meta.get("type", GameRunState.unmovable_type), textures_arr, reveals)
 
 	# connect and parent under board_container
 	if tile != null:
@@ -84,19 +84,19 @@ static func create_visual_grid(gameboard: Node, tiles_ref: Array) -> void:
 	clear_tiles(gameboard, tiles_ref)
 	await gameboard.get_tree().process_frame
 	tiles_ref.clear()
-	if GameManager.grid.size() == 0:
+	if GameRunState.grid.size() == 0:
 		gameboard.creating_visual_grid = false
 		return
 	var scale_factor = gameboard.tile_size / 64.0
 	var tiles_created = 0
-	for x in range(GameManager.GRID_WIDTH):
+	for x in range(GameRunState.GRID_WIDTH):
 		tiles_ref.append([])
-		for y in range(GameManager.GRID_HEIGHT):
+		for y in range(GameRunState.GRID_HEIGHT):
 			var tile_type = GameManager.get_tile_at(Vector2(x,y))
 			var key = str(x) + "," + str(y)
 			# If an unmovable_map entry exists, create the unmovable regardless of the grid sentinel
 			var tile = null
-			if GameManager.unmovable_map.has(key) and typeof(GameManager.unmovable_map[key]) == TYPE_DICTIONARY:
+			if GameRunState.unmovable_map.has(key) and typeof(GameRunState.unmovable_map[key]) == TYPE_DICTIONARY:
 				# hard unmovable
 				tile = gameboard.tile_scene.instantiate()
 				if tile and tile.has_method("setup"):
@@ -117,8 +117,8 @@ static func create_visual_grid(gameboard: Node, tiles_ref: Array) -> void:
 				tiles_ref[x].append(null)
 				continue
 			# configure unmovable or normal wiring
-			if GameManager.unmovable_map.has(key) and typeof(GameManager.unmovable_map[key]) == TYPE_DICTIONARY:
-				var meta = GameManager.unmovable_map[key]
+			if GameRunState.unmovable_map.has(key) and typeof(GameRunState.unmovable_map[key]) == TYPE_DICTIONARY:
+				var meta = GameRunState.unmovable_map[key]
 				if tile.has_method("configure_unmovable_hard"):
 					var textures_arr = []
 					var reveals = {}
@@ -131,20 +131,20 @@ static func create_visual_grid(gameboard: Node, tiles_ref: Array) -> void:
 							textures_arr = []
 						if typeof(reveals) != TYPE_DICTIONARY:
 							reveals = {}
-					tile.configure_unmovable_hard(meta.get("hits",1), meta.get("type", GameManager.unmovable_type), textures_arr, reveals)
+					tile.configure_unmovable_hard(meta.get("hits",1), meta.get("type", GameRunState.unmovable_type), textures_arr, reveals)
 					print("[BoardVisuals] Configured hard unmovable at (", x, ",", y, ") hits=", meta.get("hits",1))
 				else:
 					print("[BoardVisuals] WARNING: Tile missing configure_unmovable_hard at (", x, ",", y, ")")
 			else:
-				if tile_type == GameManager.COLLECTIBLE and tile.has_method("configure_collectible"):
-					tile.configure_collectible(GameManager.collectible_type)
-					print("[BoardVisuals] Configured collectible at (", x, ",", y, "): ", GameManager.collectible_type)
-				if tile_type == GameManager.SPREADER and tile.has_method("configure_spreader"):
+				if tile_type == GameRunState.COLLECTIBLE and tile.has_method("configure_collectible"):
+					tile.configure_collectible(GameRunState.collectible_type)
+					print("[BoardVisuals] Configured collectible at (", x, ",", y, "): ", GameRunState.collectible_type)
+				if tile_type == GameRunState.SPREADER and tile.has_method("configure_spreader"):
 					var textures = []
-					if GameManager.spreader_textures_map.has(GameManager.spreader_type):
-						textures = GameManager.spreader_textures_map[GameManager.spreader_type]
-					tile.configure_spreader(GameManager.spreader_grace_default, GameManager.spreader_type, textures)
-					print("[BoardVisuals] Configured spreader at (", x, ",", y, ") type='", GameManager.spreader_type, "'")
+					if GameRunState.spreader_textures_map.has(GameRunState.spreader_type):
+						textures = GameRunState.spreader_textures_map[GameRunState.spreader_type]
+					tile.configure_spreader(GameRunState.spreader_grace_default, GameRunState.spreader_type, textures)
+					print("[BoardVisuals] Configured spreader at (", x, ",", y, ") type='", GameRunState.spreader_type, "'")
 			# parent to board_container
 			if gameboard.board_container:
 				gameboard.board_container.add_child(tile)
@@ -201,7 +201,7 @@ static func create_visual_grid(gameboard: Node, tiles_ref: Array) -> void:
 		print("[BoardVisuals] sample positions col0: ", samples_col)
 
 static func spawn_collectible_visual(gameboard: Node, tiles_ref: Array, x: int, y: int, coll_type: String = "coin") -> void:
-	if x < 0 or x >= GameManager.GRID_WIDTH or y < 0 or y >= GameManager.GRID_HEIGHT:
+	if x < 0 or x >= GameRunState.GRID_WIDTH or y < 0 or y >= GameRunState.GRID_HEIGHT:
 		return
 	var existing_tile = null
 	if x < tiles_ref.size() and y < tiles_ref[x].size():

--- a/scripts/game/BoosterService.gd
+++ b/scripts/game/BoosterService.gd
@@ -96,7 +96,7 @@ static func activate_row_clear(row: int) -> void:
 		board._create_row_clear_effect(row)
 	# Logic: clear all tiles in row via GameManager
 	var to_clear = []
-	for x in range(GameManager.GRID_WIDTH):
+	for x in range(GameRunState.GRID_WIDTH):
 		if not GameManager.is_cell_blocked(x, row):
 			to_clear.append(Vector2(x, row))
 	GameManager.remove_matches(to_clear)
@@ -107,7 +107,7 @@ static func activate_column_clear(col: int) -> void:
 	if board and board.has_method("_create_column_clear_effect"):
 		board._create_column_clear_effect(col)
 	var to_clear = []
-	for y in range(GameManager.GRID_HEIGHT):
+	for y in range(GameRunState.GRID_HEIGHT):
 		if not GameManager.is_cell_blocked(col, y):
 			to_clear.append(Vector2(col, y))
 	GameManager.remove_matches(to_clear)
@@ -126,7 +126,7 @@ static func activate_bomb_3x3(x: int, y: int) -> void:
 		for dy in range(-1,2):
 			var nx = x + dx
 			var ny = y + dy
-			if nx >= 0 and nx < GameManager.GRID_WIDTH and ny >=0 and ny < GameManager.GRID_HEIGHT and not GameManager.is_cell_blocked(nx, ny):
+			if nx >= 0 and nx < GameRunState.GRID_WIDTH and ny >=0 and ny < GameRunState.GRID_HEIGHT and not GameManager.is_cell_blocked(nx, ny):
 				positions.append(Vector2(nx, ny))
 	var board = _get_board()
 	if board and board.has_method("_create_impact_particles"):
@@ -138,11 +138,11 @@ static func activate_line_blast(direction: String, x: int, y: int) -> void:
 	print("[BoosterService] activate_line_blast:", direction, x, y)
 	var positions = []
 	if direction == "horizontal":
-		for cx in range(GameManager.GRID_WIDTH):
+		for cx in range(GameRunState.GRID_WIDTH):
 			if not GameManager.is_cell_blocked(cx, y):
 				positions.append(Vector2(cx, y))
 	else:
-		for cy in range(GameManager.GRID_HEIGHT):
+		for cy in range(GameRunState.GRID_HEIGHT):
 			if not GameManager.is_cell_blocked(x, cy):
 				positions.append(Vector2(x, cy))
 	var board = _get_board()

--- a/scripts/game/CollectibleService.gd
+++ b/scripts/game/CollectibleService.gd
@@ -11,9 +11,9 @@ static func check_collectibles_at_bottom(board: Node, tiles_ref: Array) -> void:
 	## After collecting, triggers gravity → refill → cascade on the board.
 	var collectibles_to_remove = []
 
-	for x in range(GameManager.GRID_WIDTH):
+	for x in range(GameRunState.GRID_WIDTH):
 		var last_active_row = -1
-		for y in range(GameManager.GRID_HEIGHT - 1, -1, -1):
+		for y in range(GameRunState.GRID_HEIGHT - 1, -1, -1):
 			if not GameManager.is_cell_blocked(x, y):
 				last_active_row = y
 				break
@@ -44,7 +44,7 @@ static func check_collectibles_at_bottom(board: Node, tiles_ref: Array) -> void:
 
 		# Clear grid state immediately — don't wait for the animation
 		tiles_ref[int(pos.x)][int(pos.y)] = null
-		GameManager.grid[int(pos.x)][int(pos.y)] = 0
+		GameRunState.grid[int(pos.x)][int(pos.y)] = 0
 
 		# Notify game systems immediately so shard/objective logic fires at once
 		if coll_type == "shard":
@@ -86,7 +86,7 @@ static func check_collectibles_at_bottom(board: Node, tiles_ref: Array) -> void:
 				tile.queue_free()
 
 
-	if GameManager.level_transitioning:
+	if GameRunState.level_transitioning:
 		return
 	# NOTE: Do NOT call animate_gravity/animate_refill/process_cascade here.
 	# MatchOrchestrator's while-loop handles all gravity, refill, and cascade detection

--- a/scripts/game/GameFlowController.gd
+++ b/scripts/game/GameFlowController.gd
@@ -18,31 +18,31 @@ func setup(game_manager: Node) -> void:
 
 func attempt_level_complete() -> void:
 	# Do not trigger level-complete checks while the bonus cascade is already running
-	if gm.in_bonus_conversion:
+	if GameRunState.in_bonus_conversion:
 		return
-	if gm.pending_level_complete:
+	if GameRunState.pending_level_complete:
 		return
-	gm.pending_level_complete = true
+	GameRunState.pending_level_complete = true
 	gm.call_deferred("_perform_level_completion_check")
 
 func perform_level_completion_check() -> void:
-	if not gm.pending_level_complete:
+	if not GameRunState.pending_level_complete:
 		return
 	# Do not re-trigger if we are already in the bonus conversion or transitioning
-	if gm.in_bonus_conversion or gm.level_transitioning:
-		gm.pending_level_complete = false
+	if GameRunState.in_bonus_conversion or GameRunState.level_transitioning:
+		GameRunState.pending_level_complete = false
 		return
 
-	var has_collectible_goal = gm.collectible_target > 0
-	var has_unmovable_goal   = gm.unmovable_target > 0
-	var has_spreader_goal    = gm.use_spreader_objective
+	var has_collectible_goal = GameRunState.collectible_target > 0
+	var has_unmovable_goal   = GameRunState.unmovable_target > 0
+	var has_spreader_goal    = GameRunState.use_spreader_objective
 
-	var collectible_met = not has_collectible_goal or (gm.collectibles_collected >= gm.collectible_target)
-	var unmovable_met   = not has_unmovable_goal  or (gm.unmovables_cleared >= gm.unmovable_target)
-	var spreader_met    = not has_spreader_goal   or (gm.spreader_count <= 0)
+	var collectible_met = not has_collectible_goal or (GameRunState.collectibles_collected >= GameRunState.collectible_target)
+	var unmovable_met   = not has_unmovable_goal  or (GameRunState.unmovables_cleared >= GameRunState.unmovable_target)
+	var spreader_met    = not has_spreader_goal   or (GameRunState.spreader_count <= 0)
 	var has_any_primary = has_collectible_goal or has_unmovable_goal or has_spreader_goal
 
-	gm.pending_level_complete = false
+	GameRunState.pending_level_complete = false
 
 	if has_any_primary:
 		if collectible_met and unmovable_met and spreader_met:
@@ -50,49 +50,49 @@ func perform_level_completion_check() -> void:
 			gm.call_deferred("on_level_complete")
 		else:
 			if not collectible_met:
-				print("[GFC] Waiting on collectibles: %d/%d" % [gm.collectibles_collected, gm.collectible_target])
+				print("[GFC] Waiting on collectibles: %d/%d" % [GameRunState.collectibles_collected, GameRunState.collectible_target])
 			if not unmovable_met:
-				print("[GFC] Waiting on unmovables: %d/%d" % [gm.unmovables_cleared, gm.unmovable_target])
+				print("[GFC] Waiting on unmovables: %d/%d" % [GameRunState.unmovables_cleared, GameRunState.unmovable_target])
 			if not spreader_met:
-				print("[GFC] Waiting on spreaders: %d remaining" % gm.spreader_count)
+				print("[GFC] Waiting on spreaders: %d remaining" % GameRunState.spreader_count)
 	else:
-		if gm.score >= gm.target_score:
+		if GameRunState.score >= GameRunState.target_score:
 			print("[GFC] Level complete by score")
 			gm.call_deferred("on_level_complete")
 
 func on_level_complete() -> void:
 	print("[GFC] on_level_complete()")
-	if gm.level_transitioning or gm.in_bonus_conversion:
+	if GameRunState.level_transitioning or GameRunState.in_bonus_conversion:
 		return
-	gm.level_transitioning = true
+	GameRunState.level_transitioning = true
 
 	# Wait for any ongoing board activity
 	var wait_time = 0.0
-	while gm.processing_moves and wait_time < 10.0:
+	while GameRunState.processing_moves and wait_time < 10.0:
 		if gm.get_tree() == null: break
 		await gm.get_tree().create_timer(0.1).timeout
 		wait_time += 0.1
-	if gm.processing_moves:
-		gm.processing_moves = false
+	if GameRunState.processing_moves:
+		GameRunState.processing_moves = false
 	if gm.get_tree() != null:
 		await gm.get_tree().create_timer(0.2).timeout
 
-	var original_moves_left = gm.moves_left
+	var original_moves_left = GameRunState.moves_left
 
-	if gm.moves_left > 0:
-		await convert_remaining_moves_to_bonus(gm.moves_left)
-		if gm.moves_left != 0:
-			gm.moves_left = 0
-			gm.emit_signal("moves_changed", gm.moves_left)
+	if GameRunState.moves_left > 0:
+		await convert_remaining_moves_to_bonus(GameRunState.moves_left)
+		if GameRunState.moves_left != 0:
+			GameRunState.moves_left = 0
+			gm.emit_signal("moves_changed", GameRunState.moves_left)
 	else:
 		print("[GFC] No bonus moves remaining")
 
 	# Store final snapshot
-	gm.last_level_won = true
-	gm.last_level_score = gm.score
-	gm.last_level_target = gm.target_score
-	gm.last_level_number = gm.level
-	gm.last_level_moves_left = original_moves_left
+	GameRunState.last_level_won = true
+	GameRunState.last_level_score = GameRunState.score
+	GameRunState.last_level_target = GameRunState.target_score
+	GameRunState.last_level_number = GameRunState.level
+	GameRunState.last_level_moves_left = original_moves_left
 
 	# Calculate stars
 	var stars = _calculate_stars(original_moves_left)
@@ -100,15 +100,15 @@ func on_level_complete() -> void:
 
 	var star_manager = gm.get_node_or_null("/root/StarRatingManager")
 	if star_manager:
-		star_manager.save_level_stars(gm.level, stars)
+		star_manager.save_level_stars(GameRunState.level, stars)
 
 	var rm = gm.get_node_or_null("/root/RewardManager")
 	if rm and rm.has_method("grant_level_completion_reward"):
-		rm.grant_level_completion_reward(gm.level, stars)
+		rm.grant_level_completion_reward(GameRunState.level, stars)
 
 	gm.emit_signal("level_complete")
 
-	var coins_earned = 100 + (50 * gm.level)
+	var coins_earned = 100 + (50 * GameRunState.level)
 	var gems_earned  = 5 if stars == 3 else 0
 	_emit_eventbus_level_complete(stars, coins_earned, gems_earned)
 
@@ -118,106 +118,106 @@ func _calculate_stars(original_moves_left: int) -> int:
 		var level_data = gm.level_manager.get_level(gm.level_manager.current_level_index)
 		var total_moves = level_data.moves if level_data else 20
 		var moves_used  = total_moves - original_moves_left
-		return star_manager.calculate_stars(gm.score, gm.target_score, moves_used, total_moves)
-	if gm.score >= int(gm.target_score * 1.5): return 3
-	if gm.score >= int(gm.target_score * 1.2): return 2
+		return star_manager.calculate_stars(GameRunState.score, GameRunState.target_score, moves_used, total_moves)
+	if GameRunState.score >= int(GameRunState.target_score * 1.5): return 3
+	if GameRunState.score >= int(GameRunState.target_score * 1.2): return 2
 	return 1
 
 func _emit_eventbus_level_complete(stars: int, coins: int, gems: int) -> void:
-	var level_id = "level_%d" % gm.level
+	var level_id = "level_%d" % GameRunState.level
 	if EventBus:
 		EventBus.emit_level_complete(level_id, {
-			"level": gm.level, "score": gm.score,
+			"level": GameRunState.level, "score": GameRunState.score,
 			"stars": stars, "coins_earned": coins, "gems_earned": gems
 		})
 
 # ─── Level failure ───────────────────────────────────────────────────────────
 
 func perform_level_failed_check() -> void:
-	if not gm.pending_level_failed:
+	if not GameRunState.pending_level_failed:
 		return
-	if gm.pending_level_complete:
+	if GameRunState.pending_level_complete:
 		return
-	if gm.score >= gm.target_score:
+	if GameRunState.score >= GameRunState.target_score:
 		return
-	if gm.collectible_target > 0 and gm.collectibles_collected >= gm.collectible_target:
+	if GameRunState.collectible_target > 0 and GameRunState.collectibles_collected >= GameRunState.collectible_target:
 		return
 	print("[GFC] Level failed: out of moves")
-	gm.pending_level_failed = false
+	GameRunState.pending_level_failed = false
 	gm.emit_signal("game_over")
 	_emit_eventbus_level_failed()
 
 func _emit_eventbus_level_failed() -> void:
-	var level_id = "level_%d" % gm.level
+	var level_id = "level_%d" % GameRunState.level
 	if EventBus:
 		EventBus.emit_level_failed(level_id, {
-			"level": gm.level, "score": gm.score,
-			"target": gm.target_score, "moves_used": gm.moves_left
+			"level": GameRunState.level, "score": GameRunState.score,
+			"target": GameRunState.target_score, "moves_used": GameRunState.moves_left
 		})
 
 # ─── Bonus cascade ───────────────────────────────────────────────────────────
 
 func convert_remaining_moves_to_bonus(remaining_moves: int) -> void:
 	print("[GFC] convert_remaining_moves_to_bonus: %d moves" % remaining_moves)
-	gm.processing_moves = true
-	gm.bonus_skipped = false
-	gm.in_bonus_conversion = true
+	GameRunState.processing_moves = true
+	GameRunState.bonus_skipped = false
+	GameRunState.in_bonus_conversion = true
 
 	var board = gm.get_board()
 	if not board:
 		print("[GFC] GameBoard not found — skipping bonus")
-		gm.processing_moves = false
-		gm.in_bonus_conversion = false
+		GameRunState.processing_moves = false
+		GameRunState.in_bonus_conversion = false
 		return
 
 	if board.has_method("show_skip_bonus_hint"):
 		board.show_skip_bonus_hint()
 
 	for i in range(remaining_moves):
-		if gm.bonus_skipped:
+		if GameRunState.bonus_skipped:
 			for j in range(i, remaining_moves):
 				gm.add_score(100 * (j + 1))
-			gm.moves_left = 0
-			gm.emit_signal("moves_changed", gm.moves_left)
+			GameRunState.moves_left = 0
+			gm.emit_signal("moves_changed", GameRunState.moves_left)
 			break
 
 		var random_pos = _get_random_active_tile_position()
 		if random_pos == Vector2(-1, -1):
 			break
 
-		gm.grid[int(random_pos.x)][int(random_pos.y)] = gm.FOUR_WAY_ARROW
+		GameRunState.grid[int(random_pos.x)][int(random_pos.y)] = GameRunState.FOUR_WAY_ARROW
 		if board.has_method("update_tile_visual"):
-			board.update_tile_visual(random_pos, gm.FOUR_WAY_ARROW)
+			board.update_tile_visual(random_pos, GameRunState.FOUR_WAY_ARROW)
 		await gm.get_tree().create_timer(0.1).timeout
 		if board.has_method("activate_special_tile"):
 			await board.activate_special_tile(random_pos)
 
-		gm.moves_left -= 1
-		gm.emit_signal("moves_changed", gm.moves_left)
+		GameRunState.moves_left -= 1
+		gm.emit_signal("moves_changed", GameRunState.moves_left)
 		gm.add_score(100 * (i + 1))
 
 	if board.has_method("hide_skip_bonus_hint"):
 		board.hide_skip_bonus_hint()
-	if gm.bonus_skipped:
+	if GameRunState.bonus_skipped:
 		await gm.get_tree().create_timer(0.5).timeout
 		if board:
 			board.visible = false
 
-	gm.in_bonus_conversion = false
-	gm.processing_moves = false
+	GameRunState.in_bonus_conversion = false
+	GameRunState.processing_moves = false
 	print("[GFC] convert_remaining_moves_to_bonus finished")
 
 func _get_random_active_tile_position() -> Vector2:
 	var positions: Array = []
-	for x in range(gm.GRID_WIDTH):
-		for y in range(gm.GRID_HEIGHT):
-			var t = gm.grid[x][y]
-			if not gm.is_cell_blocked(x, y) and t >= 1 and t <= gm.TILE_TYPES:
+	for x in range(GameRunState.GRID_WIDTH):
+		for y in range(GameRunState.GRID_HEIGHT):
+			var t = GameRunState.grid[x][y]
+			if not gm.is_cell_blocked(x, y) and t >= 1 and t <= GameRunState.TILE_TYPES:
 				positions.append(Vector2(x, y))
 	if positions.size() == 0:
 		return Vector2(-1, -1)
 	return positions[randi() % positions.size()]
 
 func skip_bonus_animation() -> void:
-	if not gm.bonus_skipped:
-		gm.bonus_skipped = true
+	if not GameRunState.bonus_skipped:
+		GameRunState.bonus_skipped = true

--- a/scripts/game/MatchOrchestrator.gd
+++ b/scripts/game/MatchOrchestrator.gd
@@ -103,9 +103,9 @@ static func process_cascade(board: Node, gm: Node, initial_swap_pos: Vector2 = V
 
 	# --- Post-cascade: check for remaining empty cells ---
 	var has_empties := false
-	for x in range(gm.GRID_WIDTH):
-		for y in range(gm.GRID_HEIGHT):
-			if not gm.is_cell_blocked(x, y) and gm.grid[x][y] == 0:
+	for x in range(GameRunState.GRID_WIDTH):
+		for y in range(GameRunState.GRID_HEIGHT):
+			if not gm.is_cell_blocked(x, y) and GameRunState.grid[x][y] == 0:
 				has_empties = true
 				break
 		if has_empties:
@@ -124,7 +124,7 @@ static func process_cascade(board: Node, gm: Node, initial_swap_pos: Vector2 = V
 		if new_spreader_positions.size() > 0:
 			board._apply_spreader_visuals(new_spreader_positions)
 
-	gm.processing_moves = false
+	GameRunState.processing_moves = false
 	gm.reset_combo()
 	print("=== Cascade process complete (MatchOrchestrator, depth=", cascade_depth, ") ===")
 
@@ -132,14 +132,14 @@ static func process_cascade(board: Node, gm: Node, initial_swap_pos: Vector2 = V
 	board.emit_signal("board_idle")
 
 	# Level completion check — skip during bonus cascade to avoid re-entrant on_level_complete
-	if not gm.in_bonus_conversion and gm.has_method("_attempt_level_complete"):
+	if not GameRunState.in_bonus_conversion and gm.has_method("_attempt_level_complete"):
 		gm._attempt_level_complete()
 
 	if board.get_tree() != null:
 		await board.get_tree().create_timer(0.2).timeout
 
 	# Auto-shuffle if no moves available — skip during bonus (board state is managed by GFC)
-	if not gm.in_bonus_conversion and not gm.has_possible_moves():
+	if not GameRunState.in_bonus_conversion and not gm.has_possible_moves():
 		print("[MatchOrchestrator] No valid moves detected! Auto-shuffling...")
 		await board.get_tree().create_timer(1.0).timeout
 		await board.perform_auto_shuffle()

--- a/scripts/game/SpreaderService.gd
+++ b/scripts/game/SpreaderService.gd
@@ -46,7 +46,7 @@ static func damage_adjacent_unmovables(board: Node, tiles_ref: Array, matched_po
 		for dir in directions:
 			var nx = int(pos.x) + int(dir.x)
 			var ny = int(pos.y) + int(dir.y)
-			if nx < 0 or nx >= GameManager.GRID_WIDTH or ny < 0 or ny >= GameManager.GRID_HEIGHT:
+			if nx < 0 or nx >= GameRunState.GRID_WIDTH or ny < 0 or ny >= GameRunState.GRID_HEIGHT:
 				continue
 			var key = str(nx) + "," + str(ny)
 			if already_hit.has(key):
@@ -67,11 +67,11 @@ static func damage_adjacent_unmovables(board: Node, tiles_ref: Array, matched_po
 				var revealed_type = tile.tile_type if "tile_type" in tile else 0
 				var is_coll = tile.is_collectible if "is_collectible" in tile else false
 				if is_coll:
-					GameManager.grid[nx][ny] = GameManager.COLLECTIBLE
+					GameRunState.grid[nx][ny] = GameRunState.COLLECTIBLE
 				elif revealed_type > 0:
-					GameManager.grid[nx][ny] = revealed_type
+					GameRunState.grid[nx][ny] = revealed_type
 				else:
-					GameManager.grid[nx][ny] = 0
+					GameRunState.grid[nx][ny] = 0
 					tiles_ref[nx][ny] = null
 					if not tile.is_queued_for_deletion():
 						tile.queue_free()
@@ -97,16 +97,16 @@ static func damage_adjacent_spreaders(board: Node, tiles_ref: Array, matched_pos
 		for dir in directions:
 			var nx = int(pos.x) + int(dir.x)
 			var ny = int(pos.y) + int(dir.y)
-			if nx < 0 or nx >= GameManager.GRID_WIDTH or ny < 0 or ny >= GameManager.GRID_HEIGHT:
+			if nx < 0 or nx >= GameRunState.GRID_WIDTH or ny < 0 or ny >= GameRunState.GRID_HEIGHT:
 				continue
 			var key = str(nx) + "," + str(ny)
 			if already_hit.has(key):
 				continue
-			if GameManager.get_tile_at(Vector2(nx, ny)) != GameManager.SPREADER:
+			if GameManager.get_tile_at(Vector2(nx, ny)) != GameRunState.SPREADER:
 				continue
 			already_hit[key] = true
 
-			GameManager.grid[nx][ny] = 0
+			GameRunState.grid[nx][ny] = 0
 			GameManager.report_spreader_destroyed(Vector2(nx, ny))
 			if nx < tiles_ref.size() and ny < tiles_ref[nx].size():
 				var tile = tiles_ref[nx][ny]
@@ -126,8 +126,8 @@ static func apply_spreader_visuals(board: Node, tiles_ref: Array, new_positions:
 	## Reconfigure visual tiles at newly-infected spreader positions.
 	var scale_factor = board.tile_size / 64.0
 	var textures: Array = []
-	if GameManager.spreader_textures_map.has(GameManager.spreader_type):
-		textures = GameManager.spreader_textures_map[GameManager.spreader_type]
+	if GameRunState.spreader_textures_map.has(GameRunState.spreader_type):
+		textures = GameRunState.spreader_textures_map[GameRunState.spreader_type]
 
 	for pos in new_positions:
 		var x = int(pos.x)
@@ -138,9 +138,9 @@ static func apply_spreader_visuals(board: Node, tiles_ref: Array, new_positions:
 		var tile = tiles_ref[x][y]
 		if tile == null or not is_instance_valid(tile) or tile.is_queued_for_deletion():
 			var new_tile = board.tile_scene.instantiate()
-			new_tile.setup(GameManager.SPREADER, pos, scale_factor)
+			new_tile.setup(GameRunState.SPREADER, pos, scale_factor)
 			if new_tile.has_method("configure_spreader"):
-				new_tile.configure_spreader(GameManager.spreader_grace_default, GameManager.spreader_type, textures)
+				new_tile.configure_spreader(GameRunState.spreader_grace_default, GameRunState.spreader_type, textures)
 			new_tile.position = board.grid_to_world_position(pos)
 			new_tile.connect("tile_clicked",  Callable(board, "_on_tile_clicked"))
 			new_tile.connect("tile_swiped",   Callable(board, "_on_tile_swiped"))
@@ -151,6 +151,6 @@ static func apply_spreader_visuals(board: Node, tiles_ref: Array, new_positions:
 			tiles_ref[x][y] = new_tile
 		else:
 			if tile.has_method("configure_spreader"):
-				tile.configure_spreader(GameManager.spreader_grace_default, GameManager.spreader_type, textures)
+				tile.configure_spreader(GameRunState.spreader_grace_default, GameRunState.spreader_type, textures)
 			else:
-				tile.update_type(GameManager.SPREADER)
+				tile.update_type(GameRunState.SPREADER)


### PR DESCRIPTION
### Summary

Migrates all pure data-field reads and writes across 12 files from the
`GameManager` autoload to the new `GameRunState` autoload introduced in
PR 5a. `GameManager` remains alive as a coordinator; only its data
surface is no longer the authoritative source of truth for callers.

Also fixes a pre-existing bug uncovered by the migration: `activate_special_tile`
in `BoardActionExecutor` set `processing_moves = true` but never cleared it,
causing the board to freeze permanently after any special-tile activation.

---

### What changed

#### Data field migration (`GameManager.X` → `GameRunState.X`)

All 48 data fields (grid, score, moves_left, level, flags, constants, collectibles,
unmovables, spreaders, boosters) are now read from and written to `GameRunState`
in the following files:

| File | Notes |
|---|---|
| `scripts/GameBoard.gd` | Constants, `initialized`, `processing_moves` |
| `scripts/game/BoardActionExecutor.gd` | All grid/flag/constant accesses (119 → `GameRunState`) |
| `scripts/game/BoardAnimator.gd` | `GRID_WIDTH/HEIGHT`, `is_cell_blocked` guard |
| `scripts/game/BoardInputHandler.gd` | `processing_moves`, `level_transitioning`, tile constants |
| `scripts/game/BoardLayout.gd` | `GRID_WIDTH/HEIGHT`, `is_cell_blocked` guard |
| `scripts/game/BoardSetup.gd` | All grid dimension and flag resets |
| `scripts/game/BoardVisuals.gd` | All grid, unmovable, spreader, collectible constants |
| `scripts/game/BoosterService.gd` | Grid dimensions and tile constants |
| `scripts/game/CollectibleService.gd` | `GRID_WIDTH/HEIGHT`, `COLLECTIBLE` constant |
| `scripts/game/GameFlowController.gd` | All `gm.*` data fields → `GameRunState.*` |
| `scripts/game/MatchOrchestrator.gd` | `processing_moves`, `in_bonus_conversion`, `grid`, constants |
| `scripts/game/SpreaderService.gd` | `GRID_WIDTH/HEIGHT`, spreader state, `SPREADER` constant |

#### What stays on `GameManager`

All method calls remain on `GameManager` — it is still the coordinator:
`get_tile_at`, `is_cell_blocked`, `find_matches`, `swap_tiles`, `use_move`,
`add_score`, `remove_matches`, `calculate_points`, `report_unmovable_destroyed`,
`report_spreader_destroyed`, `shuffle_until_moves_available`, `register_board`,
`reset_combo`, `emit_signal`, `get_board`.

#### Bug fix — board freeze after special tile activation

`BoardActionExecutor.activate_special_tile` set `GameRunState.processing_moves = true`
at entry but had no matching `= false` at exit. After PR 5b, `BoardInputHandler`
reads `GameRunState.processing_moves` (not `GameManager.processing_moves`), so
the board was permanently locked after any horizontal, vertical, or four-way
special tile was activated. Added the missing `GameRunState.processing_moves = false`
before the completion log line.

#### `GameFlowController` and `MatchOrchestrator` — missed in initial sweep

These two files were not in the original PR 5b file list but write data fields
via the `gm` reference (`gm.processing_moves`, `gm.in_bonus_conversion`,
`gm.level_transitioning`, `gm.grid`, etc.). Because `BoardInputHandler` now
reads those flags from `GameRunState`, any mutation in `GameFlowController` or
`MatchOrchestrator` via `gm.*` was invisible to the board. Both files are now
fully migrated.

---

### Files changed

```
scripts/GameBoard.gd                  | 16 +++----
scripts/game/BoardActionExecutor.gd   | 179 ++++----
scripts/game/BoardAnimator.gd         |   8 +++----
scripts/game/BoardInputHandler.gd     |  16 +++----
scripts/game/BoardLayout.gd           |  12 +++++----
scripts/game/BoardSetup.gd            |  28 +++----
scripts/game/BoardVisuals.gd          |  36 +++----
scripts/game/BoosterService.gd        |  10 +++----
scripts/game/CollectibleService.gd    |   8 +++----
scripts/game/GameFlowController.gd    | 140 +++----
scripts/game/MatchOrchestrator.gd     |  12 +++++----
scripts/game/SpreaderService.gd       |  26 +++----
12 files changed, 246 insertions(+), 245 deletions(-)
```

---

### How to test

1. Run the game and load any level — board should initialize and be fully interactive.
2. Make a normal swap match — cascade, gravity, refill should all complete normally.
3. Create or tap a **horizontal arrow** special tile — board should unfreeze after activation completes.
4. Create or tap a **vertical arrow** special tile — same as above.
5. Create or tap a **four-way arrow** special tile — same as above.
6. Activate any booster (hammer, bomb, row clear, etc.) — board should remain interactive after.
7. Complete a level (score / collectible / unmovable objective) — win flow and rewards screen should trigger.
8. Lose a level (run out of moves) — game over screen should trigger.
9. Open Settings and Gallery from the floating menu — no regressions.

---

### Notes

- `GameManager` still exists as an autoload. It is not deleted in this PR (that is PR 5d).
- `GameManager` still owns all its original `var` declarations — the migration only changed *callers*, not the source. `GameManager._push_to_grs()` keeps both in sync during the transition window.
- No `.tscn` or `.tres` files were modified.
- No UI, gallery, narrative, or audio code was touched.

---


